### PR TITLE
A couple of fixes and corrections

### DIFF
--- a/DMA-Queue.asm
+++ b/DMA-Queue.asm
@@ -185,17 +185,19 @@ QueueStaticDMA_defined = 1
 ; at assembly time. Gives errors if DMA starts at an odd address, transfers
 ; crosses a 128kB boundary, or has size 0.
 QueueStaticDMA macro src,length,dest
-	if ((src)&1)<>0
-		fatal "DMA queued from odd source $\{src}!"
-	endif
-	if ((length)&1)<>0
-		fatal "DMA an odd number of bytes $\{length}!"
-	endif
-	if (length)==0
-		fatal "DMA transferring 0 bytes (becomes a 64kB transfer). If you really mean it, pass 64kB (65536) instead."
-	endif
-	if (((src)+(length)-1)>>17)<>((src)>>17)
-		fatal "DMA crosses a 128kB boundary. You should either split the DMA manually or align the source adequately."
+	if MOMPASS>1
+		if ((src)&1)<>0
+			fatal "DMA queued from odd source $\{src}!"
+		endif
+		if ((length)&1)<>0
+			fatal "DMA an odd number of bytes $\{length}!"
+		endif
+		if (length)==0
+			fatal "DMA transferring 0 bytes (becomes a 64kB transfer). If you really mean it, pass 64kB (65536) instead."
+		endif
+		if (((src)+(length)-1)>>17)<>((src)>>17)
+			fatal "DMA crosses a 128kB boundary. You should either split the DMA manually or align the source adequately."
+		endif
 	endif
 	if UseVIntSafeDMA==1
 		move.w	sr,-(sp)										; Save current interrupt mask

--- a/DMA-Queue.asm
+++ b/DMA-Queue.asm
@@ -246,8 +246,8 @@ QueueDMATransfer:
 
 	if Use128kbSafeDMA<>0
 		; Detect if transfer crosses 128KB boundary
-		sub.w	d1,d0										; Set d0 to the number of words until end of current 128kB block
-		cmp.w	d3,d0										; Are we transferring more than that?
+		move.w	d1,d0
+		add.w	d3,d0										; Does adding the length to the source address overflow the current 128kB block?
 		bcs.s	.doubletransfer								; Branch if yes
 	endif	; Use128kbSafeDMA
 	; It does not cross a 128kB boundary. So just finish writing it.
@@ -270,6 +270,8 @@ QueueDMATransfer:
 	if Use128kbSafeDMA<>0
 .doubletransfer:
 		; We need to split the DMA into two parts, since it crosses a 128kB block
+		moveq	#0,d0
+		sub.w	d1,d0										; Set d0 to the number of words until end of current 128kB block
 		movep.w	d0,DMAEntry.Size(a1)						; Write DMA length of first part, overwriting useless top byte of source addres
 
 		cmpa.w	#VDP_Command_Buffer_Slot-DMAEntry.len,a1	; Does the queue have enough space for both parts?

--- a/DMA-Queue.asm
+++ b/DMA-Queue.asm
@@ -184,17 +184,17 @@ QueueStaticDMA_defined = 1
 ; Expects source address and DMA length in bytes. Also, expects source, size, and dest to be known
 ; at assembly time. Gives errors if DMA starts at an odd address, transfers
 ; crosses a 128kB boundary, or has size 0.
-QueueStaticDMA macro source,length,dest
-	if (source&1)<>0
-		fatal "DMA queued from odd source $\{source}!"
+QueueStaticDMA macro src,length,dest
+	if ((src)&1)<>0
+		fatal "DMA queued from odd source $\{src}!"
 	endif
-	if (length&1)<>0
+	if ((length)&1)<>0
 		fatal "DMA an odd number of bytes $\{length}!"
 	endif
-	if length==0
+	if (length)==0
 		fatal "DMA transferring 0 bytes (becomes a 64kB transfer). If you really mean it, pass 64kB (65536) instead."
 	endif
-	if ((source+length-1)>>17)<>(source>>17)
+	if (((src)+(length)-1)>>17)<>((src)>>17)
 		fatal "DMA crosses a 128kB boundary. You should either split the DMA manually or align the source adequately."
 	endif
 	if UseVIntSafeDMA==1
@@ -205,7 +205,7 @@ QueueStaticDMA macro source,length,dest
 	cmpa.w	#VDP_Command_Buffer_Slot,a1
 	beq.s	.done												; Return if there's no more room in the buffer
 	move.b	#(dmaLength(length)>>8)&$FF,DMAEntry.SizeH(a1)		; Write top byte of size/2
-	move.l	#(dmaLength(length)&$FF)<<24)|dmaSource(source),d0	; Set d0 to bottom byte of size/2 and the low 3 bytes of source/2
+	move.l	#((dmaLength(length)&$FF)<<24)|dmaSource(src),d0	; Set d0 to bottom byte of size/2 and the low 3 bytes of source/2
 	movep.l	d0,DMAEntry.SizeL(a1)								; Write it all to the queue
 	lea	DMAEntry.Command(a1),a1									; Seek to correct RAM address to store VDP DMA command
 	move.l	#vdpComm(dest,VRAM,DMA),(a1)+						; Write VDP DMA command for destination address

--- a/DMA-Queue.asm
+++ b/DMA-Queue.asm
@@ -325,10 +325,10 @@ ProcessDMAQueue:
 	endm
 ; ---------------------------------------------------------------------------
 c := 1
-	rept QueueSlotCount-1
+	rept QueueSlotCount
 		lea	(VDP_control_port).l,a5
 		lea	(VDP_Command_Buffer).w,a1
-		if c<>QueueSlotCount-1
+		if c<>QueueSlotCount
 			bra.w	.jump0 - c*8
 		endif
 c := c + 1

--- a/README.md
+++ b/README.md
@@ -115,11 +115,11 @@ Add this line after the above block:
 ```
 Then scan further down until you find this:
 ```68k
-	clearRAM PNT_Buffer,$C04	; PNT buffer
+	clearRAM SS_Misc_Variables,SS_Misc_Variables_End+4
 ```
 and change it to this:
 ```68k
-	clearRAM PNT_Buffer,$C00	; PNT buffer
+	clearRAM SS_Misc_Variables,SS_Misc_Variables_End
 ```
 And finally find this:
 ```68k


### PR DESCRIPTION
Like I said in the third commit, I'm not sure if anything can be done about the '[symbol] must be evaluatable in the first pass' error. It seems the labels need defining before the macro is used, which is pretty awkward.