### PR TITLE
A tiny instruction optimization in `InitDMAQueue`.

### DIFF
--- a/DMA-Queue.asm
+++ b/DMA-Queue.asm
@@ -370,7 +370,7 @@ c := c + 1
 
 InitDMAQueue:
 	lea	(VDP_Command_Buffer).w,a0
-	move.b	#$94,d0
+	moveq	#-$6C,d0				; fast-store $94 (sign-extended) in d0
 	move.l	#$93979695,d1
 c := 0
 	rept QueueSlotCount


### PR DESCRIPTION
This PR addresses issue #5.

The `move.b #$94,d0` instruction in **InitDMAQueue** is replaced with `moveq #-$6C,d0`, which effectively stores the sign-extended long-word $FFFFFF94 in d0.
Since only the lower byte of the register is used in the loop, the optimized instruction doesn't affect code execution, while saving 1 bus cycle and 2 bytes in total.